### PR TITLE
Output formatting

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func Set(h *heroku.Heroku, args []string) {
 		console.Fatalf("failed setting %s: %v", strings.Join(args, " "), err)
 	}
 
-	fmt.Printf(console.Success(fmt.Sprintf("Successfully set %d configuration %s\n", len(cfg), pluralize("variable", "", "s", len(cfg)))))
+	fmt.Println(console.Success("Successfully set %d configuration %s", len(cfg), pluralize("variable", "", "s", len(cfg))))
 }
 
 func Pull(h *heroku.Heroku, args []string) {
@@ -91,7 +91,7 @@ func Pull(h *heroku.Heroku, args []string) {
 	if len(args) >= 1 {
 		destination = args[0]
 		if !console.ConfirmOverwrite(destination) {
-			console.Fatalf(console.Error("Aborting\n"))
+			console.Fatalln(console.Error("Aborting"))
 		}
 	}
 
@@ -133,7 +133,7 @@ func Push(h *heroku.Heroku, args []string) {
 		console.Fatalf("failed pushing config: %v", err)
 	}
 
-	fmt.Printf(console.Success(fmt.Sprintf("Successfully pushed %d configuration %s.\n", len(cfg), pluralize("variable", "", "s", len(cfg)))))
+	fmt.Println(console.Success("Successfully pushed %d configuration %s.", len(cfg), pluralize("variable", "", "s", len(cfg))))
 }
 
 func PushNew(h *heroku.Heroku, args []string) {
@@ -161,7 +161,7 @@ func PushNew(h *heroku.Heroku, args []string) {
 	}
 
 	if len(newConfig) == 0 {
-		fmt.Println(console.Success("No new configuration variables."))
+		fmt.Println(console.Warning("No new configuration variables."))
 		return
 	}
 
@@ -170,7 +170,7 @@ func PushNew(h *heroku.Heroku, args []string) {
 		console.Fatalf("failed pushing config to application: %v", err)
 	}
 
-	fmt.Println(console.Success(fmt.Sprintf("Successfully pushed %d new configuration %s.", len(newConfig), pluralize("variable", "", "s", len(newConfig)))))
+	fmt.Println(console.Success("Successfully pushed %d new configuration %s.", len(newConfig), pluralize("variable", "", "s", len(newConfig))))
 }
 
 func Search(h *heroku.Heroku, args []string) {

--- a/main.go
+++ b/main.go
@@ -160,12 +160,17 @@ func PushNew(h *heroku.Heroku, args []string) {
 		}
 	}
 
+	if len(newConfig) == 0 {
+		fmt.Println(console.Success("No new configuration variables."))
+		return
+	}
+
 	err = h.SetConfig(newConfig)
 	if err != nil {
 		console.Fatalf("failed pushing config to application: %v", err)
 	}
 
-	fmt.Print(console.Success(fmt.Sprintf("Successfully pushed %d new configuration %s.", len(cfg), pluralize("variable", "", "s", len(cfg)))))
+	fmt.Println(console.Success(fmt.Sprintf("Successfully pushed %d new configuration %s.", len(newConfig), pluralize("variable", "", "s", len(newConfig)))))
 }
 
 func Search(h *heroku.Heroku, args []string) {
@@ -196,7 +201,7 @@ func Search(h *heroku.Heroku, args []string) {
 				}
 				fmt.Print(console.ConfigKey(rs))
 			}
-			fmt.Printf("%s\n", console.ConfigValue(fmt.Sprintf("%s=", v)))
+			fmt.Printf("=%s\n", console.ConfigValue(v))
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a few command output issues that I found.

1. Print a message when there are no new configuration variables to push with `push:new`, previously the heroku command was run without any config variables which caused the following error:
```
failed pushing config to application: Heroku CLI (exit status 1): 
 ▸    Usage: heroku config:set KEY1=VALUE1 [KEY2=VALUE2 ...]
 ▸    Must specify KEY and VALUE to set.
```

2. Show the number of new configuration variables that was pushed with `push:new` after successful push, instead of the number of configuration variables in the input file. Also use `fmt.Println` instead of `fmt.Print`.

3. Fix incorrect output from the `search` command where `=` was misplaced. Example of previous output: 
```
% ./herofig --app=[redacted] search TEST
TEST_ENVgood-morning=
TEST_ENV_2HELLO=
TEST_HELLOhello=
```
Fixed output:
```
% ./herofig --app=[redacted] search TEST
TEST_ENV=good-morning
TEST_ENV_2=HELLO
TEST_HELLO=hello
```